### PR TITLE
Add support for Devuan images.

### DIFF
--- a/.github/workflows/ci-deuvan.yml
+++ b/.github/workflows/ci-deuvan.yml
@@ -1,0 +1,126 @@
+name: sd-card-devuan CI
+
+on:
+  push:
+    branches: "*"
+  pull_request:
+    branches:
+      - "master"
+  schedule:
+    # Every Sunday morning
+    - cron: "00 03 * * 0"
+
+jobs:
+  test-debian-x86:
+    runs-on: ubuntu-latest
+    name: test ${{ matrix.os }} ${{ matrix.arch }} ${{ matrix.suite }}
+
+    strategy:
+      matrix:
+        include:
+          - os: devuan
+            suite: daedalus
+            arch: i386
+          - os: devuan
+            suite: excalibur
+            arch: i386
+          - os: devuan
+            suite: ceres
+            arch: i386
+      fail-fast: false
+
+    env:
+      DEBIAN_OS: ${{ matrix.os }}
+      DEBIAN_ARCH: ${{ matrix.arch }}
+      DEBIAN_SUITE: ${{ matrix.suite }}
+
+    steps:
+    - name: Install dependencies
+      timeout-minutes: 5
+      env:
+        DEBIAN_FRONTEND: noninteractive
+      run: |
+        sudo apt-get update
+        sudo apt-get --assume-yes \
+                     --no-install-recommends \
+                     install bc \
+                             bison \
+                             bzip2 \
+                             ca-certificates \
+                             debian-archive-keyring \
+                             debootstrap \
+                             device-tree-compiler \
+                             dosfstools \
+                             e2fsprogs \
+                             flex \
+                             gcc \
+                             gcc-arm-none-eabi \
+                             gcc-i686-linux-gnu \
+                             git \
+                             libssl-dev \
+                             make \
+                             mtools \
+                             parted \
+                             pigz \
+                             pwgen \
+                             python2-dev \
+                             python3-dev \
+                             python3-pkg-resources \
+                             ssh \
+                             sshpass \
+                             swig \
+                             qemu-system-x86
+
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Build qemu_x86_virt
+      timeout-minutes: 5
+      run: |
+        env PATH=$GITHUB_WORKSPACE/scripts:$PATH \
+            ARTIFACTS_DIR=$RUNNER_TEMP \
+            U_BOOT_GIT_REV="v2023.07" \
+            U_BOOT_GIT_URL="https://github.com/u-boot/u-boot.git" \
+            build-boot qemu_x86_virt \
+                       qemu-x86 \
+                       qemu-x86_defconfig \
+                       i686-linux-gnu
+
+    - name: Build ${{ matrix.suite }} ${{ matrix.arch }}
+      timeout-minutes: 5
+      run: |
+        sudo env PATH=$GITHUB_WORKSPACE/scripts:$PATH \
+                 ARTIFACTS_DIR=$RUNNER_TEMP \
+                 build-debian $DEBIAN_OS \
+                              $DEBIAN_ARCH \
+                              $DEBIAN_SUITE
+
+    - name: Test qemu_x86_virt + ${{ matrix.suite }} ${{ matrix.arch }}
+      timeout-minutes: 15
+      run: |
+        sudo ./test/qemu.sh $RUNNER_TEMP/boot-qemu_x86_virt.bin.gz \
+                            $RUNNER_TEMP/${{ matrix.os }}-${{ matrix.suite }}-${{ matrix.arch }}-*.bin.gz
+
+  build-docker:
+    runs-on: ubuntu-latest
+    needs: test-debian-x86
+    name: build docker images
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        timeout-minutes: 1
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        timeout-minutes: 1
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build
+        timeout-minutes: 30
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64

--- a/.github/workflows/ci-deuvan.yml
+++ b/.github/workflows/ci-deuvan.yml
@@ -20,10 +20,13 @@ jobs:
         include:
           - os: devuan
             suite: ceres
-            arch: i386
+            arch: arm64
+          - os: devuan
+            suite: daedalus
+            arch: arm64
           - os: devuan
             suite: excalibur
-            arch: i386
+            arch: arm64
       fail-fast: false
 
     env:

--- a/.github/workflows/ci-deuvan.yml
+++ b/.github/workflows/ci-deuvan.yml
@@ -21,12 +21,6 @@ jobs:
           - os: devuan
             suite: daedalus
             arch: i386
-          - os: devuan
-            suite: excalibur
-            arch: i386
-          - os: devuan
-            suite: ceres
-            arch: i386
       fail-fast: false
 
     env:

--- a/.github/workflows/ci-deuvan.yml
+++ b/.github/workflows/ci-deuvan.yml
@@ -19,14 +19,11 @@ jobs:
       matrix:
         include:
           - os: devuan
-            suite: ceres
-            arch: arm64
-          - os: devuan
             suite: daedalus
-            arch: arm64
+            arch: i386
           - os: devuan
             suite: excalibur
-            arch: arm64
+            arch: i386
       fail-fast: false
 
     env:

--- a/.github/workflows/ci-deuvan.yml
+++ b/.github/workflows/ci-deuvan.yml
@@ -19,7 +19,10 @@ jobs:
       matrix:
         include:
           - os: devuan
-            suite: daedalus
+            suite: ceres
+            arch: i386
+          - os: devuan
+            suite: excalibur
             arch: i386
       fail-fast: false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,8 @@ jobs:
       env:
         DEBIAN_FRONTEND: noninteractive
       run: |
+        echo "Manual explicit 'exit 1' from 'Install dependencies' in ci.yml"
+        exit 1
         sudo apt-get update
         sudo apt-get --assume-yes \
                      --no-install-recommends \

--- a/.github/workflows/csv.yml
+++ b/.github/workflows/csv.yml
@@ -14,19 +14,21 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+            ref: add_devuan
 
       - name: Rebuild
         timeout-minutes: 5
         run: |
           set -e
-          git config user.name "Johan Gunnarsson"
-          git config user.email "johan.gunnarsson@gmail.com"
+          git config user.name "watchful-0wl"
+          git config user.email "watchful@tagmar.net"
           ./metascripts/rebuild-debian-csv
           git add debians-arm.csv debians-x86.csv
-          if git commit -m "debians: Update Debian/Ubuntu versions"; then
+          if git commit -m "debians: Update Devuan/Debian/Ubuntu versions"; then
             ./metascripts/rebuild-jekyll-boards
             git add -A docs
             if git commit -m "docs: Regenerate boards"; then
-              git push origin
+              git push origin add_devuan
             fi
           fi

--- a/.github/workflows/csv.yml
+++ b/.github/workflows/csv.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-            ref: add_devuan
+            ref:  add_devuan
 
       - name: Rebuild
         timeout-minutes: 5

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM devuan/devuan:daedalus.
+FROM devuan/devuan:daedalus
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
     apt-get --assume-yes \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,9 @@
-FROM public.ecr.aws/ubuntu/ubuntu:24.04
+FROM devuan/devuan:daedalus.
 ENV DEBIAN_FRONTEND=noninteractive
-
-# Need Devuan's debootstrap, which also supports Debian and Ubuntu.
-# Use Ubuntu's gpg to get Devuan's signing key.
-RUN apt-get update && apt-get install -y gpg
-
-# Add Devuan's signing key.
-ARG RELEASE_KEY="94532124541922FB" # ceres key - https://www.devuan.org/os/keyring
-RUN echo "Adding Devuan ceres signing key (https://www.devuan.org/os/keyring):" ${RELEASE_KEY}
-RUN gpg --keyserver keyring.devuan.org --recv-keys ${RELEASE_KEY} && \
-    gpg --export ${RELEASE_KEY} >/etc/apt/trusted.gpg.d/devuan_key.gpg
-
-# Get Devuan's debootstrap.
-RUN echo 'deb http://deb.devuan.org/merged ceres main ' > /etc/apt/sources.list.d/devuan.list
 RUN apt-get update && \
     apt-get --assume-yes \
             --no-install-recommends \
-            install -t ceres debootstrap
-
-# Install everything else but debootstrap from Ubuntu.
-RUN apt-get update && \
-    apt-get --assume-yes \
-            --no-install-recommends \
-            install -t noble \
+            install debootstrap \
                     debian-archive-keyring \
                     ca-certificates \
                     qemu-user \
@@ -40,6 +21,7 @@ RUN apt-get update && \
                     bison \
                     flex \
                     python3-dev \
+                    python3-lxml \
                     python3-pkg-resources \
                     python3-pyelftools \
                     python3-setuptools \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update && \
                     bison \
                     flex \
                     python3-dev \
+                    python3-lxml \
                     python3-pkg-resources \
                     python3-pyelftools \
                     python3-setuptools \

--- a/Dockerfile.devuan
+++ b/Dockerfile.devuan
@@ -1,4 +1,4 @@
-FROM devuan/devuan:daedalus.
+FROM devuan/devuan:daedalus
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
     apt-get --assume-yes \

--- a/Dockerfile.devuan
+++ b/Dockerfile.devuan
@@ -22,6 +22,7 @@ RUN apt-get update && \
                     bison \
                     flex \
                     python3-dev \
+                    python3-lxml\
                     python3-pkg-resources \
                     python3-pyelftools \
                     python3-setuptools \

--- a/Dockerfile.devuan
+++ b/Dockerfile.devuan
@@ -1,11 +1,29 @@
-FROM devuan/devuan:daedalus
+FROM public.ecr.aws/ubuntu/ubuntu:24.04
 ENV DEBIAN_FRONTEND=noninteractive
+
+# Need Devuan's debootstrap, which also supports Debian and Ubuntu.
+# Use Ubuntu's gpg to get Devuan's signing key.
+RUN apt-get update && apt-get install -y gpg
+
+# Add Devuan's signing key.
+ARG RELEASE_KEY="94532124541922FB" # ceres key - https://www.devuan.org/os/keyring
+RUN echo "Adding Devuan ceres signing key (https://www.devuan.org/os/keyring):" ${RELEASE_KEY}
+RUN gpg --keyserver keyring.devuan.org --recv-keys ${RELEASE_KEY} && \
+    gpg --export ${RELEASE_KEY} >/etc/apt/trusted.gpg.d/devuan_key.gpg
+
+# Get Devuan's debootstrap.
+RUN echo 'deb http://deb.devuan.org/merged ceres main ' > /etc/apt/sources.list.d/devuan.list
 RUN apt-get update && \
     apt-get --assume-yes \
             --no-install-recommends \
-            install debootstrap \
+            install -t ceres debootstrap
+
+# Install everything else but debootstrap from Ubuntu.
+RUN apt-get update && \
+    apt-get --assume-yes \
+            --no-install-recommends \
+            install -t noble \
                     debian-archive-keyring \
-                    ubuntu-archive-keyring \
                     ca-certificates \
                     qemu-user \
                     qemu-user-static \
@@ -22,7 +40,6 @@ RUN apt-get update && \
                     bison \
                     flex \
                     python3-dev \
-                    python3-lxml\
                     python3-pkg-resources \
                     python3-pyelftools \
                     python3-setuptools \

--- a/Dockerfile.devuan
+++ b/Dockerfile.devuan
@@ -5,6 +5,7 @@ RUN apt-get update && \
             --no-install-recommends \
             install debootstrap \
                     debian-archive-keyring \
+                    ubuntu-archive-keyring \
                     ca-certificates \
                     qemu-user \
                     qemu-user-static \

--- a/Dockerfile.devuan
+++ b/Dockerfile.devuan
@@ -1,28 +1,9 @@
-FROM public.ecr.aws/ubuntu/ubuntu:24.04
+FROM devuan/devuan:daedalus.
 ENV DEBIAN_FRONTEND=noninteractive
-
-# Need Devuan's debootstrap, which also supports Debian and Ubuntu.
-# Use Ubuntu's gpg to get Devuan's signing key.
-RUN apt-get update && apt-get install -y gpg
-
-# Add Devuan's signing key.
-ARG RELEASE_KEY="94532124541922FB" # ceres key - https://www.devuan.org/os/keyring
-RUN echo "Adding Devuan ceres signing key (https://www.devuan.org/os/keyring):" ${RELEASE_KEY}
-RUN gpg --keyserver keyring.devuan.org --recv-keys ${RELEASE_KEY} && \
-    gpg --export ${RELEASE_KEY} >/etc/apt/trusted.gpg.d/devuan_key.gpg
-
-# Get Devuan's debootstrap.
-RUN echo 'deb http://deb.devuan.org/merged ceres main ' > /etc/apt/sources.list.d/devuan.list
 RUN apt-get update && \
     apt-get --assume-yes \
             --no-install-recommends \
-            install -t ceres debootstrap
-
-# Install everything else but debootstrap from Ubuntu.
-RUN apt-get update && \
-    apt-get --assume-yes \
-            --no-install-recommends \
-            install -t noble \
+            install debootstrap \
                     debian-archive-keyring \
                     ca-certificates \
                     qemu-user \
@@ -40,6 +21,7 @@ RUN apt-get update && \
                     bison \
                     flex \
                     python3-dev \
+                    python3-lxml \
                     python3-pkg-resources \
                     python3-pyelftools \
                     python3-setuptools \

--- a/Dockerfile.devuan
+++ b/Dockerfile.devuan
@@ -1,0 +1,59 @@
+FROM devuan/devuan:daedalus
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && \
+    apt-get --assume-yes \
+            --no-install-recommends \
+            install debootstrap \
+                    debian-archive-keyring \
+                    ca-certificates \
+                    qemu-user \
+                    qemu-user-static \
+                    qemu-system-arm \
+                    qemu-system-x86 \
+                    device-tree-compiler \
+                    gcc \
+                    gcc-arm-none-eabi \
+                    make \
+                    git \
+                    bc \
+                    bzip2 \
+                    pigz \
+                    bison \
+                    flex \
+                    python3-dev \
+                    python3-pkg-resources \
+                    python3-pyelftools \
+                    python3-setuptools \
+                    swig \
+                    parted \
+                    e2fsprogs \
+                    dosfstools \
+                    mtools \
+                    pwgen \
+                    libssl-dev \
+                    libgnutls28-dev \
+                    uuid-dev \
+                    parallel \
+                    ssh \
+                    sshpass \
+                    unzip && \
+    ([ "$(uname -m)" = "aarch64" ] && \
+     apt-get --assume-yes \
+             install gcc-arm-linux-gnueabihf \
+                     gcc-i686-linux-gnu \
+                     gcc-x86-64-linux-gnu || :) && \
+    ([ "$(uname -m)" = "x86_64" ] && \
+     apt-get --assume-yes \
+             install gcc-arm-linux-gnueabihf \
+                     gcc-aarch64-linux-gnu \
+                     gcc-i686-linux-gnu || :) && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm -f /var/log/*.log
+RUN wget -q "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -O "awscliv2.zip" && \
+    unzip -q awscliv2.zip && \
+    ./aws/install && \
+    rm -rf aws
+ENV PATH="/debimg/scripts:${PATH}"
+COPY . /debimg
+WORKDIR /debimg

--- a/README_devuan.md
+++ b/README_devuan.md
@@ -78,9 +78,9 @@ The image will end up in /tmp/sd-images on the host as `${BOARD_ID}.bin.gz`.
 For any valid combination provided by the distribution:
   |Variable      |   |   |   |
   |--------------|---|---|---|
-  | DISTRIBUTION | Devuan | Debian | Ubuntu |
+  | DISTRIBUTION | **Devuan** | Debian | Ubuntu |
   | ARCH         | armhf, arm64, i386, amd64 | armhf, arm64, i386, amd64 | armhf, arm64, i386, amd64 |
-  | RELEASE      | e.g. daedalus, excalibur, ceres | e.g bookworm, trixie, sid | e.g. focal, jammy, noble |
+  | RELEASE      | e.g. **daedalus**, excalibur, ceres | e.g bookworm, trixie, sid | e.g. focal, jammy, noble |
 
 To build:
 ```bash

--- a/README_devuan.md
+++ b/README_devuan.md
@@ -7,6 +7,21 @@ That project describes itself as
 a bunch of scripts to build SD card images that various single-board computers (SBC) can boot.
 Emphasis is on pureness; pure Debian and pure mainline U-boot.
 ```
+The main implementation change is that the Dockerfile (`Dockerfile.devuan`) uses `FROM devuan/devuan:daedalus`.
+
+## Index
+- [Pre-built images](#pre-built-images)
+- [Usage](#usage)
+- - [Build your own boot image](#build-your-own-boot-image)
+- - [Build your own Devuan ext4 root filesystem image](build-your-own-devuan-ext4-root-filesystem-image)
+- [Examples](#examples)
+- - [Example boot image](#example-boot-image)
+- - - [To build a boot image for Raspberry Pi 3 B](#to-build-a-boot-image-for-raspberry-pi-3-b)
+- - - [To build a boot image for Pine64 Rockpro64](#to-build-a-boot-image-for-pine64-rockpro64)
+- - - [To build a boot image for Sinovoip Banana Pi M2 Zero](#to-build-a-boot-image-for-sinovoip-banana-pi-m2-zero)
+- - [Example root filesystem image](#example-root-filesystem-image)
+- - - [To build a Devuan ext4 root filesystem image for arm64](#to-build-a-devuan-ext4-root-filesystem-image-for-arm64)
+- - - [To build a Devuan ext4 root filesystem image for armhf](#to-build-a-devuan-ext4-root-filesystem-image-for-armhf)
 
 ## Pre-built images
 
@@ -79,11 +94,11 @@ docker run --rm \
 
 The image will end up in /tmp/sd-images on the host as `${DISTRIBUTION}-${ARCH}-${RELEASE}-${PASSWORD}.bin`.
 
-## Examples ##
+## Examples
 
-### Example boot image ###
+### Example boot image
 
-#### To build a boot image for Raspberry Pi 3 B:
+#### To build a boot image for Raspberry Pi 3 B
 
 ```bash
 docker build -t devuan/sd-images -f Dockerfile.devuan https://github.com/watchful-0wl/sd-card-images.git#add_devuan
@@ -99,7 +114,7 @@ docker run --rm \
 
 The image will end up in /tmp/sd-images on the host.
 
-#### To build a boot image for Pine64 Rockpro64:
+#### To build a boot image for Pine64 Rockpro64
 
 ```bash
 docker build -t devuan/sd-images -f Dockerfile.devuan https://github.com/watchful-0wl/sd-card-images.git#add_devuan
@@ -131,9 +146,9 @@ docker run --rm \
 
 The image will end up in /tmp/sd-images on the host.
 
-### Example root filesystem image ###
+### Example root filesystem image
 
-#### To build a Devuan ext4 root filesystem image for arm64:
+#### To build a Devuan ext4 root filesystem image for arm64
 
 ```bash
 docker build -t devuan/sd-images -f Dockerfile.devuan https://github.com/watchful-0wl/sd-card-images.git#add_devuan
@@ -146,7 +161,7 @@ docker run --rm \
 
 The image will end up in /tmp/sd-images on the host.
 
-#### To build a Devuan ext4 root filesystem image for armhf:
+#### To build a Devuan ext4 root filesystem image for armhf
 
 ```bash
 docker build -t devuan/sd-images -f Dockerfile.devuan https://github.com/watchful-0wl/sd-card-images.git#add_devuan

--- a/README_devuan.md
+++ b/README_devuan.md
@@ -1,31 +1,99 @@
 # Devuan SD card images
 
-This repository is a bunch of scripts to build SD card images that various [single-board computers](https://en.wikipedia.org/wiki/Single-board_computer) (SBC) can boot. Emphasis is on pureness; pure Debian and pure mainline U-boot.
+This repository simply adds Devuan to a fork of https://github.com/johang/sd-card-images.  Please do not report any Devuan-issues to johang.
+
+That project describes itself as
+```
+a bunch of scripts to build SD card images that various single-board computers (SBC) can boot. Emphasis is on pureness; pure Debian and pure mainline U-boot.
+```
 
 ## Pre-built images
 
-Pre-built images ready for download are availble at [sd-card-images.johang.se](https://sd-card-images.johang.se).
+Pre-built images for Debian are available from the original project at [sd-card-images.johang.se](https://sd-card-images.johang.se).
+
+There are no pre-built images for Devuan.
+
+## If you have problems here ##
+
+This project is just a fork.  If anything works at all, credit goes to johang.
+
+If you have problems building a Devuan image here, please first try to build a Debian image using https://github.com/johang/sd-card-images.
+
+Please do not report any Devuan-issues to johang, his interest is in pure Debian.
 
 ## Usage
 
 The generated SD card images are made up of two separate images:
 
 - **boot-BOARD.bin**: Boot image that contains partition table, U-Boot and chip-specific code. The boot image will only work on the board it's built for. The filename indicates which board it's built for.
-- **debian-ARCH-VERSION-PASSWORD.bin**: Debian ext4 root filesystem image that contains a complete Debian installation, including kernel, initrd and device tree. This Debian image is generic and will work on all chips and boards with the CPU architecture it's built for. The filename indicates Debian version, CPU architecture and default root password.
+- **devuan-ARCH-VERSION-PASSWORD.bin**: Devuan ext4 root filesystem image that contains a complete Devuan installation, including kernel, initrd and device tree. This Devuan image is generic and will work on all chips and boards with the CPU architecture it's built for. The filename indicates Devuan version, CPU architecture and default root password.
 
 These two images are the concatenated to a single image, which is then written to SD card, for example like this:
 
-    $ zcat boot-raspberrypi_3b.bin.gz debian-buster-arm64-XXXXXX.bin.gz > sd-card.img
+    $ zcat boot-raspberrypi_3b.bin.gz devuan-daedalus-arm64-XXXXXX.bin.gz > sd-card.img
     # dd if=sd-card.img of=/dev/sdXXX
 
-### Build your own Devuan boot image
+### Build your own boot image
+
+See many appropriate values of BOARD_ID and CHIP_ID at https://sd-card-images.johang.se/.
+
+For any valid combination of:
+  | Variable |  |
+  |----------|-------------------------|
+  | BOARD_ID | e.g. bananapi, pinebook |
+  | CHIP_ID  | e.g. allwinner-a10, rk3399 |
+  | CONFIG   | e.g. Bananapi_defconfig |
+  | TUPLE    | e.g. arm-linux-gnueabihf, aarch64-linux-gnu |
+
+To build:
+```bash
+docker build -t devuan/sd-images -f Dockerfile.devuan https://github.com/watchful-0wl/sd-card-images.git#add_devuan
+mkdir -p /tmp/sd-images
+docker run --rm \
+  -v /tmp/sd-images:/artifacts \
+  devuan/sd-images \
+  build-boot ${BOARD_ID} ${CHIP_ID} ${CONFIG} ${TUPLE}
+```
+
+The image will end up in /tmp/sd-images on the host as `${BOARD_ID}.bin.gz`.
+
+### Build your own Devuan ext4 root filesystem image
+
+For any valid combination provided by the distribution:
+  |Variable      |   |   |   |
+  |--------------|---|---|---|
+  | DISTRIBUTION | Devuan | Debian | Ubuntu |
+  | ARCH         | armhf, arm64, i386, amd64 | armhf, arm64, i386, amd64 | armhf, arm64, i386, amd64 |
+  | RELEASE      | e.g. daedalus, excalibur, ceres | e.g bookworm, trixie, sid | e.g. focal, jammy, noble |
+
+To build:
+```bash
+docker build -t devuan/sd-images -f Dockerfile.devuan https://github.com/watchful-0wl/sd-card-images.git#add_devuan
+mkdir -p /tmp/sd-images
+docker run --rm \
+  -v /tmp/sd-images:/artifacts \
+  devuan/sd-images \
+  build-debian ${DISTRIBUTION} ${ARCH} ${RELEASE}
+```
+
+The image will end up in /tmp/sd-images on the host as `${DISTRIBUTION}-${ARCH}-${RELEASE}-${PASSWORD}.bin`.
+
+## Examples ##
+
+### Example boot image ###
 
 #### To build a boot image for Raspberry Pi 3 B:
 
 ```bash
 docker build -t devuan/sd-images -f Dockerfile.devuan https://github.com/watchful-0wl/sd-card-images.git#add_devuan
 mkdir -p /tmp/sd-images
-docker run --rm -v /tmp/sd-images:/artifacts sd-images build-boot raspberrypi_3b bcm2837 rpi_3_defconfig aarch64-linux-gnu
+docker run --rm \
+  -v /tmp/sd-images:/artifacts \
+  devuan/sd-images \
+  build-boot raspberrypi_3b \
+             bcm2837 \
+             rpi_3_defconfig \
+             aarch64-linux-gnu
 ```
 
 The image will end up in /tmp/sd-images on the host.
@@ -38,7 +106,10 @@ mkdir -p /tmp/sd-images
 docker run --rm \
   -v /tmp/sd-images:/artifacts \
   devuan/sd-images \
-  build-boot ROCKPro64 rk3399 rockpro64-rk3399_defconfig aarch64-linux-gnu
+  build-boot ROCKPro64 \
+             rk3399 \
+             rockpro64-rk3399_defconfig \
+             aarch64-linux-gnu
 ```
 
 The image will end up in /tmp/sd-images on the host.
@@ -51,12 +122,15 @@ mkdir -p /tmp/sd-images
 docker run --rm \
   -v /tmp/sd-images:/artifacts \
   devuan/sd-images \
-  build-boot banana_pi_m2_zero allwinner-h2+ bananapi_m2_zero_defconfig arm-linux-gnueabihf
+  build-boot banana_pi_m2_zero \
+             allwinner-h2+ \
+             bananapi_m2_zero_defconfig \
+             arm-linux-gnueabihf
 ```
 
 The image will end up in /tmp/sd-images on the host.
 
-### Build your own Debian ext4 root filesystem image
+### Example root filesystem image ###
 
 #### To build a Devuan ext4 root filesystem image for arm64:
 
@@ -65,7 +139,6 @@ docker build -t devuan/sd-images -f Dockerfile.devuan https://github.com/watchfu
 mkdir -p /tmp/sd-images
 docker run --rm \
   -v /tmp/sd-images:/artifacts \
-  --privileged \
   devuan/sd-images \
   build-debian devuan arm64 daedalus
 ```
@@ -79,7 +152,6 @@ docker build -t devuan/sd-images -f Dockerfile.devuan https://github.com/watchfu
 mkdir -p /tmp/sd-images
 docker run --rm \
   -v /tmp/sd-images:/artifacts \
-  --privileged \
   devuan/sd-images \
   build-debian devuan armhf daedalus
 ```

--- a/README_devuan.md
+++ b/README_devuan.md
@@ -4,7 +4,8 @@ This repository simply adds Devuan to a fork of https://github.com/johang/sd-car
 
 That project describes itself as
 ```
-a bunch of scripts to build SD card images that various single-board computers (SBC) can boot. Emphasis is on pureness; pure Debian and pure mainline U-boot.
+a bunch of scripts to build SD card images that various single-board computers (SBC) can boot.
+Emphasis is on pureness; pure Debian and pure mainline U-boot.
 ```
 
 ## Pre-built images

--- a/README_devuan.md
+++ b/README_devuan.md
@@ -1,0 +1,87 @@
+# Devuan SD card images
+
+This repository is a bunch of scripts to build SD card images that various [single-board computers](https://en.wikipedia.org/wiki/Single-board_computer) (SBC) can boot. Emphasis is on pureness; pure Debian and pure mainline U-boot.
+
+## Pre-built images
+
+Pre-built images ready for download are availble at [sd-card-images.johang.se](https://sd-card-images.johang.se).
+
+## Usage
+
+The generated SD card images are made up of two separate images:
+
+- **boot-BOARD.bin**: Boot image that contains partition table, U-Boot and chip-specific code. The boot image will only work on the board it's built for. The filename indicates which board it's built for.
+- **debian-ARCH-VERSION-PASSWORD.bin**: Debian ext4 root filesystem image that contains a complete Debian installation, including kernel, initrd and device tree. This Debian image is generic and will work on all chips and boards with the CPU architecture it's built for. The filename indicates Debian version, CPU architecture and default root password.
+
+These two images are the concatenated to a single image, which is then written to SD card, for example like this:
+
+    $ zcat boot-raspberrypi_3b.bin.gz debian-buster-arm64-XXXXXX.bin.gz > sd-card.img
+    # dd if=sd-card.img of=/dev/sdXXX
+
+### Build your own Devuan boot image
+
+#### To build a boot image for Raspberry Pi 3 B:
+
+```bash
+docker build -t devuan/sd-images -f Dockerfile.devuan https://github.com/watchful-0wl/sd-card-images.git#add_devuan
+mkdir -p /tmp/sd-images
+docker run --rm -v /tmp/sd-images:/artifacts sd-images build-boot raspberrypi_3b bcm2837 rpi_3_defconfig aarch64-linux-gnu
+```
+
+The image will end up in /tmp/sd-images on the host.
+
+#### To build a boot image for Pine64 Rockpro64:
+
+```bash
+docker build -t devuan/sd-images -f Dockerfile.devuan https://github.com/watchful-0wl/sd-card-images.git#add_devuan
+mkdir -p /tmp/sd-images
+docker run --rm \
+  -v /tmp/sd-images:/artifacts \
+  devuan/sd-images \
+  build-boot ROCKPro64 rk3399 rockpro64-rk3399_defconfig aarch64-linux-gnu
+```
+
+The image will end up in /tmp/sd-images on the host.
+
+#### To build a boot image for Sinovoip Banana Pi M2 Zero
+
+```bash
+docker build -t devuan/sd-images -f Dockerfile.devuan https://github.com/watchful-0wl/sd-card-images.git#add_devuan
+mkdir -p /tmp/sd-images
+docker run --rm \
+  -v /tmp/sd-images:/artifacts \
+  devuan/sd-images \
+  build-boot banana_pi_m2_zero allwinner-h2+ bananapi_m2_zero_defconfig arm-linux-gnueabihf
+```
+
+The image will end up in /tmp/sd-images on the host.
+
+### Build your own Debian ext4 root filesystem image
+
+#### To build a Devuan ext4 root filesystem image for arm64:
+
+```bash
+docker build -t devuan/sd-images -f Dockerfile.devuan https://github.com/watchful-0wl/sd-card-images.git#add_devuan
+mkdir -p /tmp/sd-images
+docker run --rm \
+  -v /tmp/sd-images:/artifacts \
+  --privileged \
+  devuan/sd-images \
+  build-debian devuan arm64 daedalus
+```
+
+The image will end up in /tmp/sd-images on the host.
+
+#### To build a Devuan ext4 root filesystem image for armhf:
+
+```bash
+docker build -t devuan/sd-images -f Dockerfile.devuan https://github.com/watchful-0wl/sd-card-images.git#add_devuan
+mkdir -p /tmp/sd-images
+docker run --rm \
+  -v /tmp/sd-images:/artifacts \
+  --privileged \
+  devuan/sd-images \
+  build-debian devuan armhf daedalus
+```
+
+The image will end up in /tmp/sd-images on the host.

--- a/debians-arm.csv
+++ b/debians-arm.csv
@@ -9,6 +9,16 @@ debian,sid,armhf,"Debian unstable (""sid"")",False
 debian,sid,arm64,"Debian unstable (""sid"")",False
 debian,experimental,armhf,"Debian experimental (""rc-buggy"")",True
 debian,experimental,arm64,"Debian experimental (""rc-buggy"")",True
+devuan,ceres,armhf,"Devuan unstable/1.0.0 (""ceres"")",False
+devuan,ceres,arm64,"Devuan unstable/1.0.0 (""ceres"")",False
+devuan,beowulf,armhf,"Devuan oldoldstable/3.0 (""beowulf"")",False
+devuan,beowulf,arm64,"Devuan oldoldstable/3.0 (""beowulf"")",False
+devuan,chimaera,armhf,"Devuan oldstable/4.0 (""chimaera"")",False
+devuan,chimaera,arm64,"Devuan oldstable/4.0 (""chimaera"")",False
+devuan,daedalus,armhf,"Devuan stable/5.0 (""daedalus"")",False
+devuan,daedalus,arm64,"Devuan stable/5.0 (""daedalus"")",False
+devuan,excalibur,armhf,"Devuan testing/6.0 (""excalibur"")",False
+devuan,excalibur,arm64,"Devuan testing/6.0 (""excalibur"")",False
 ubuntu,focal,armhf,"Ubuntu 20.04 LTS (""focal"")",False
 ubuntu,focal,arm64,"Ubuntu 20.04 LTS (""focal"")",False
 ubuntu,jammy,armhf,"Ubuntu 22.04 LTS (""jammy"")",False

--- a/debians-x86.csv
+++ b/debians-x86.csv
@@ -9,6 +9,16 @@ debian,sid,i386,"Debian unstable (""sid"")",False
 debian,sid,amd64,"Debian unstable (""sid"")",False
 debian,experimental,i386,"Debian experimental (""rc-buggy"")",True
 debian,experimental,amd64,"Debian experimental (""rc-buggy"")",True
+devuan,ceres,i386,"Devuan unstable/1.0.0 (""ceres"")",False
+devuan,ceres,amd64,"Devuan unstable/1.0.0 (""ceres"")",False
+devuan,beowulf,i386,"Devuan oldoldstable/3.0 (""beowulf"")",False
+devuan,beowulf,amd64,"Devuan oldoldstable/3.0 (""beowulf"")",False
+devuan,chimaera,i386,"Devuan oldstable/4.0 (""chimaera"")",False
+devuan,chimaera,amd64,"Devuan oldstable/4.0 (""chimaera"")",False
+devuan,daedalus,i386,"Devuan stable/5.0 (""daedalus"")",False
+devuan,daedalus,amd64,"Devuan stable/5.0 (""daedalus"")",False
+devuan,excalibur,i386,"Devuan testing/6.0 (""excalibur"")",False
+devuan,excalibur,amd64,"Devuan testing/6.0 (""excalibur"")",False
 ubuntu,focal,i386,"Ubuntu 20.04 LTS (""focal"")",False
 ubuntu,focal,amd64,"Ubuntu 20.04 LTS (""focal"")",False
 ubuntu,jammy,i386,"Ubuntu 22.04 LTS (""jammy"")",False

--- a/metascripts/rebuild-debian-csv
+++ b/metascripts/rebuild-debian-csv
@@ -21,14 +21,26 @@ class Release:
         for line in fileobj:
             line = line.decode('utf-8').strip()
             # Header of "Release" finishes at:
-            #   "MD5Sum:"	Debian/Ubuntu
-            if line == "MD5Sum:":
+            #   "MD5Sum:" in Debian/Ubuntu
+            #   "SHA256:" in Devuan
+            if line == "MD5Sum:" or line == "SHA256:":
                 break
 
             k, v = line.split(": ", 1)
             params[k] = v
 
-        self.label = params.get("Label")
+        # In Release files,
+        #    e.g. https://ftp.debian.org/debian/dists/stable/Release
+        # "Origin" is Debian/Ubuntu/Devuan as expected.
+        # "Origin" = "Label" for Debian and Ubuntu, not always for Devuan.
+        # "Label" is "Debian"/"Ubuntu" for Debian/Ubuntu.
+        # "Label" is "Devuan" or "Master" for Devuan.
+        # "Label" of "Master" has no equivalent in Debian/Ubuntu.
+        #
+        # Where this program uses "label" it really wants "origin".
+        self.origin = params.get("Origin")
+        self.label = self.origin
+
         self.suite = params.get("Suite")
         self.version = params.get("Version")
         self.codename = params.get("Codename")
@@ -86,16 +98,29 @@ class Release:
             return date.today() - release_date
 
     def is_relevant(self):
-        if self.label not in ("Debian", "Ubuntu", ):
+        if self.label not in ("Debian", "Ubuntu", "Devuan", ):
             return False
 
-        bl1 = ("oldoldstable", "devel", )
-        if self.suite in bl1:
-            return False
+        if self.label == "Debian" or self.label == "Ubuntu":
+            bl1 = ("oldoldstable", "devel", )
+            if self.suite in bl1:
+                return False
 
-        bl2 = ("-updates", "-backports", "-security", "-proposed", "-sloppy", )
-        if any(self.suite.endswith(suffix) for suffix in bl2):
-            return False
+            bl2 = ("-updates", "-backports", "-security", "-proposed", "-sloppy", )
+            if any(self.suite.endswith(suffix) for suffix in bl2):
+                return False
+
+        if self.label == "Devuan":
+            # "oldoldstable" is maintained in Devuan.
+            # These are no longer maintained.
+            bl_ = ("jessie", "ascii", )
+            if self.suite in bl_:
+                return False
+
+            # For fine-grained control:
+            bl_ = ("-backports", "-security", "-proposed-updates", )
+            if any(self.suite.endswith(suffix) for suffix in bl_):
+                return False
 
         if self.label == "Ubuntu":
             if self.is_lts():
@@ -109,6 +134,8 @@ class Release:
         if self.label == "Debian" and self.suite == "experimental":
             return True
         if self.label == "Ubuntu" and self.age() < timedelta(days=0):
+            return True
+        if self.label == "Devuan" and self.suite == "experimental":
             return True
 
         return False
@@ -249,6 +276,7 @@ def write_csv(filename, releases, archs):
 
         for r in releases:
             if not r.is_relevant():
+                logger.debug("Discarding as not relevant: %s ", repr(r))
                 continue
 
             for arch in archs:
@@ -275,7 +303,9 @@ if __name__ == "__main__":
     assert len(debianreleases) > 0
     ubuntureleases = set(get_dist_releases("http://ftp.ubuntu.com/ubuntu"))
     assert len(ubuntureleases) > 0
-    releases = list(sorted(debianreleases | ubuntureleases))
+    devuanreleases = set(get_dist_releases("http://deb.devuan.org/merged"))
+    assert len(devuanreleases) > 0
+    releases = list(sorted(debianreleases | ubuntureleases | devuanreleases))
     assert len(releases) > 0
     logger.info("Found %d releases", len(releases))
 

--- a/metascripts/rebuild-debian-csv
+++ b/metascripts/rebuild-debian-csv
@@ -19,11 +19,13 @@ class Release:
     def __init__(self, fileobj):
         params = {}
         for line in fileobj:
-            line = line.decode("utf-8")
-            if line.startswith(" ") or ": " not in line:
-                continue
+            line = line.decode('utf-8').strip()
+            # Header of "Release" finishes at:
+            #   "MD5Sum:"	Debian/Ubuntu
+            if line == "MD5Sum:":
+                break
 
-            k, v = line.strip().split(": ", 1)
+            k, v = line.split(": ", 1)
             params[k] = v
 
         self.label = params.get("Label")
@@ -112,6 +114,13 @@ class Release:
         return False
 
 
+"""
+# Note: get_releases(url) is deprecated because it can not work with Devuan.
+# Instead, use get_dist_releases(url).
+# 
+# get_releases(url) requires the file ls-lR.gz to be present.
+# This is not available in Devuan.
+#
 def get_releases(url):
     dirlinepattern = re.compile(
         r"\.(/dists/[\w\-]+):"
@@ -172,6 +181,65 @@ def get_releases(url):
                             yield Release(u)
                     except urllib.error.URLError as e:
                         logger.warning("Failed to download %s: %s", relurl, e)
+"""
+
+
+def get_dist_releases(url):
+
+    from lxml import html
+
+    # Open the web page listurl and use an xpath to extract the dist names.
+    listurl = url + "/dists/"
+
+    try:
+        tree = html.fromstring(urllib.request.urlopen(listurl).read())
+        logger.debug("Downloaded %s", listurl)
+    except urllib.error.URLError as e:
+        logger.warning("Failed to download %s: %s", listurl, e)
+    else:
+        # Extract dist names from the web links.
+        """
+        Finds <a href="{debiandir}"> in the web page.
+
+        Using Xpath 1.0:
+          matches: buster/, daedalus/, noble/, oldstable, stable/, unstable/
+          does not match: ../, /debian/, daedalus-updates/, 6.0/
+
+
+        The chosen xpath:
+
+            dist_path = "//a[contains(@href,'/') \
+                                      and not(starts-with(@href,'/')) \
+                                      and not(contains(@href,'-')) \
+                                      and not(contains(@href,'.')) \
+                                     ]/@href"
+
+        will select only hrefs which are:
+            not, e.g., /debian/         not(starts-with(@href,'/'))
+            directories                 contains(@href,'/')
+            codenames                   not(contains(@href,'-'))
+            not numbers or ../          not(contains(@href,'.'))
+
+        This excludes all "-updates", "-backports", "-security", "-proposed", etc.
+        """
+        dist_path = "//a[contains(@href,'/') \
+                         and not(starts-with(@href,'/')) \
+                         and not(contains(@href,'-')) \
+                         and not(contains(@href,'.')) \
+                        ]/@href"
+
+        dist_names = tree.xpath(dist_path)
+
+        for debiandir in dist_names:
+            relurl = listurl + debiandir + "Release"
+
+            try:
+                with urllib.request.urlopen(relurl) as u:
+                    logger.debug("Downloaded %s", relurl)
+
+                    yield Release(u)
+            except urllib.error.URLError as e:
+                logger.warning("Failed to download %s: %s", relurl, e)
 
 
 def write_csv(filename, releases, archs):
@@ -203,9 +271,9 @@ def write_csv(filename, releases, archs):
 
 if __name__ == "__main__":
     logger.info("Downloading releases...")
-    debianreleases = set(get_releases("http://ftp.debian.org/debian"))
+    debianreleases = set(get_dist_releases("http://ftp.debian.org/debian"))
     assert len(debianreleases) > 0
-    ubuntureleases = set(get_releases("http://ftp.ubuntu.com/ubuntu"))
+    ubuntureleases = set(get_dist_releases("http://ftp.ubuntu.com/ubuntu"))
     assert len(ubuntureleases) > 0
     releases = list(sorted(debianreleases | ubuntureleases))
     assert len(releases) > 0

--- a/scripts/build-boot
+++ b/scripts/build-boot
@@ -1,6 +1,9 @@
 #!/bin/sh
 # Build SD card image
 
+echo "Sorry, these scripts worked yesterday."
+exit 1
+
 BOARD_ID="${1}" # For example "bananapi"
 CHIP_ID="${2}" # For example "allwinner-a10"
 DEFCONFIG="${3}" # For example "Bananapi_defconfig"

--- a/scripts/build-boot
+++ b/scripts/build-boot
@@ -1,9 +1,6 @@
 #!/bin/sh
 # Build SD card image
 
-echo "Sorry, these scripts worked yesterday."
-exit 1
-
 BOARD_ID="${1}" # For example "bananapi"
 CHIP_ID="${2}" # For example "allwinner-a10"
 DEFCONFIG="${3}" # For example "Bananapi_defconfig"

--- a/scripts/build-boot-rpi
+++ b/scripts/build-boot-rpi
@@ -73,7 +73,8 @@ sed -i -e "s/BOOT_UART=0/BOOT_UART=1/" bootcode.bin
 
 # Create empty FAT partition
 rm -f vfat.img
-fallocate -l 28MiB vfat.img
+# fallocate fails on some (git CI) COW filesystems, so have a coreutils alternative.
+fallocate -l 28MiB vfat.img || truncate --size 28MiB vfat.img
 mkfs.vfat vfat.img
 
 # Copy boot files to FAT partition

--- a/scripts/build-debian
+++ b/scripts/build-debian
@@ -1,9 +1,6 @@
 #!/bin/sh
 # Build Debian root filesystem
 
-echo "Sorry, these scripts worked yesterday."
-exit 1
-
 OS="$1" # For example "debian"
 ARCH="$2" # For example "armhf"
 DIST="$3" # For example "buster"

--- a/scripts/build-debian
+++ b/scripts/build-debian
@@ -150,7 +150,7 @@ devuan)
 	    gpg --export ${RELEASE_KEY} >/etc/apt/trusted.gpg.d/devuan_key.gpg
 
 	# Get Devuan's debootstrap.
-	echo 'deb http://deb.devuan.org/merged ${DIST} main' > /etc/apt/sources.list.d/devuan.list
+	echo "deb http://deb.devuan.org/merged ${DIST} main" > /etc/apt/sources.list.d/devuan.list
 	apt-get update && apt-get --assume-yes \
 		--no-install-recommends \
 		install --force-yes -t ${DIST} debootstrap

--- a/scripts/build-debian
+++ b/scripts/build-debian
@@ -268,7 +268,7 @@ cp -rv --preserve=mode ../2nd-stage-files/pre-2nd-stage-files/* ${OS}
 cp -rv --preserve=mode ../2nd-stage-files/pre-2nd-stage-files-${ARCH}/* ${OS}
 
 # Copy ARM emulation stuff
-cp -v /usr/bin/qemu-*-static ${OS}/usr/bin || :
+cp -v /usr/bin/qemu-*-static ${OS}/usr/bin || true
 
 # Build a Debian root filesystem (second stage)
 case "${OS}" in

--- a/scripts/build-debian
+++ b/scripts/build-debian
@@ -183,6 +183,13 @@ deb http://ports.ubuntu.com/ubuntu-ports ${DIST}-security main universe
 deb-src http://ports.ubuntu.com/ubuntu-ports ${DIST}-security main universe
 EOF
 	;;
+devuan-*-excalibur | devuan-*-testing)
+	# https://pkginfo.devuan.org/sources.list.txt
+	tee debian/tmp/sources.list <<-EOF
+deb http://deb.devuan.org/merged ${DIST} main
+deb-src http://deb.devuan.org/merged ${DIST} main
+EOF
+	;;
 devuan-*-ceres | devuan-*-unstable)
 	# https://pkginfo.devuan.org/sources.list.txt
 	tee debian/tmp/sources.list <<-EOF

--- a/scripts/build-debian
+++ b/scripts/build-debian
@@ -128,7 +128,7 @@ openssh-server,\
 nano,\
 vim-tiny \
   "${TARGET}" \
-  debian \
+  devuan \
   "${URL}" \
   "${SCRIPT}"
 	;;

--- a/scripts/build-debian
+++ b/scripts/build-debian
@@ -268,6 +268,12 @@ cp -rv --preserve=mode ../2nd-stage-files/pre-2nd-stage-files/* ${OS}
 cp -rv --preserve=mode ../2nd-stage-files/pre-2nd-stage-files-${ARCH}/* ${OS}
 
 # Copy ARM emulation stuff
+apt-cache policy \
+                    qemu-user \
+                    qemu-system-arm \
+                    qemu-system-x86 
+
+apt-cache policy   qemu-user-static \
 cp -v /usr/bin/qemu-*-static ${OS}/usr/bin || true
 
 # Build a Debian root filesystem (second stage)

--- a/scripts/build-debian
+++ b/scripts/build-debian
@@ -227,24 +227,20 @@ EOF
 	;;
 devuan-*-excalibur | devuan-*-testing)
 	# https://pkginfo.devuan.org/sources.list.txt
-	tee debian/tmp/sources.list <<-EOF
+	tee devuan/tmp/sources.list <<-EOF
 deb http://deb.devuan.org/merged ${DIST} main
 deb-src http://deb.devuan.org/merged ${DIST} main
 EOF
 	;;
 devuan-*-ceres | devuan-*-unstable)
 	# https://pkginfo.devuan.org/sources.list.txt
-	tee debian/tmp/sources.list <<-EOF
+	tee devuan/tmp/sources.list <<-EOF
 deb http://deb.devuan.org/merged ${DIST} main
 deb-src http://deb.devuan.org/merged ${DIST} main
 EOF
 	;;
 devuan-*)
-pwd
-
-ls -l .
-ls -l debian
-	tee debian/tmp/sources.list <<-EOF
+	tee devuan/tmp/sources.list <<-EOF
 deb http://deb.devuan.org/merged ${DIST} main
 deb-src http://deb.devuan.org/merged ${DIST} main
 deb http://deb.devuan.org/merged ${DIST}-updates main
@@ -268,11 +264,11 @@ EOF
 	;;
 esac
 
-cp -rv --preserve=mode ../2nd-stage-files/pre-2nd-stage-files/* debian
-cp -rv --preserve=mode ../2nd-stage-files/pre-2nd-stage-files-${ARCH}/* debian
+cp -rv --preserve=mode ../2nd-stage-files/pre-2nd-stage-files/* ${OS}
+cp -rv --preserve=mode ../2nd-stage-files/pre-2nd-stage-files-${ARCH}/* ${OS}
 
 # Copy ARM emulation stuff
-cp -v /usr/bin/qemu-*-static debian/usr/bin || :
+cp -v /usr/bin/qemu-*-static ${OS}/usr/bin || :
 
 # Build a Debian root filesystem (second stage)
 case "${OS}" in
@@ -301,7 +297,7 @@ EOF
 	;;
 devuan)
 	# Build a Devuan root filesystem (second stage)
-chroot debian /bin/sh -ex <<-EOF
+chroot devuan /bin/sh -ex <<-EOF
 /debootstrap/debootstrap --second-stage
 /bin/mv /tmp/sources.list /etc/apt/sources.list
 # /usr/bin/apt-key add /etc/apt/trusted.gpg.d/devuan_key.gpg
@@ -322,12 +318,12 @@ EOF
 esac
 
 # Remove ARM emulation stuff again
-rm -v debian/usr/bin/qemu-*-static || :
+rm -v ${OS}/usr/bin/qemu-*-static || :
 
-cp -rv --preserve=mode ../2nd-stage-files/post-2nd-stage-files/* debian
+cp -rv --preserve=mode ../2nd-stage-files/post-2nd-stage-files/* ${OS}
 
 # Set hostname
-echo "${OS}" > debian/etc/hostname
+echo "${OS}" > ${OS}/etc/hostname
 
 # Set resolv.conf
 case "${OS}" in
@@ -335,14 +331,14 @@ debian | ubuntu)
 	ln -sf /run/systemd/resolve/stub-resolv.conf debian/etc/resolv.conf
 	;;
 devuan)
-	ln -sf /run/connman/resolv.conf debian/etc/resolv.conf
+	ln -sf /run/connman/resolv.conf devuan/etc/resolv.conf
 	;;
 esac
 
 # List all files
-find debian ! -type d -printf "/%P\n" | sort > files.txt
+find ${OS} ! -type d -printf "/%P\n" | sort > files.txt
 
-mv debian/tmp/versions.csv versions.csv
+mv ${OS}/tmp/versions.csv versions.csv
 
 # Make a ext4 filesystem of this and put it into the image
 # >>> ((3800000000 - 32 * 1024 * 1024) // (1024 * 1024)) * (1024 * 1024)

--- a/scripts/build-debian
+++ b/scripts/build-debian
@@ -346,7 +346,7 @@ mv ${OS}/tmp/versions.csv versions.csv
 rm -f ext4.img
 # fallocate fails on some (git CI) COW filesystems, so have a coreutils alternative.
 fallocate -l 3765436416 ext4.img || truncate --size=3765436416 ext4.img
-mkfs.ext4 -d debian ext4.img
+mkfs.ext4 -d ${OS} ext4.img
 pigz ext4.img
 
 mkdir -p "${ARTIFACTS_DIR:-/artifacts}"

--- a/scripts/build-debian
+++ b/scripts/build-debian
@@ -94,6 +94,10 @@ cd "${TMP}"
 # Build a Debian root filesystem (first stage)
 case ${OS} in
 debian | ubuntu)
+	# Get Debian keyring when in Devuan image.
+	apt-get update && apt-get --assume-yes \
+		--no-install-recommends \
+		install debian-archive-keyring
 debootstrap \
   --arch="${ARCH}" \
   --verbose \

--- a/scripts/build-debian
+++ b/scripts/build-debian
@@ -113,6 +113,39 @@ nano \
   "${SCRIPT}"
 	;;
 devuan)
+	# Need Devuan's keys and Devuan's debootstrap.
+	case ${DIST} in
+	ceres | beowulf | chimaera | daedalus)
+		# https://www.devuan.org/os/keyring
+		# Ceres, Beowulf, Chimaera and Daedalus
+		RELEASE_KEY="94532124541922FB"
+		;;
+	excalibur)
+		RELEASE_KEY="B3982868D104092C"
+		;;
+	freia)
+		RELEASE_KEY="55C470D57732684B"
+		;;
+	*)
+		echo "Can't decide release key for \"${DIST}\""
+		exit 1
+		;;
+	esac
+
+	# Use Ubuntu's gpg to get Devuan's signing key.
+	apt-get update && apt-get install -y gpg
+
+	# Add Devuan's signing key.
+	echo "Adding Devuan ${DIST} signing key (https://www.devuan.org/os/keyring):" ${RELEASE_KEY}
+	gpg --keyserver keyring.devuan.org --recv-keys ${RELEASE_KEY} && \
+	    gpg --export ${RELEASE_KEY} >/etc/apt/trusted.gpg.d/devuan_key.gpg
+
+	# Get Devuan's debootstrap.
+	echo 'deb http://deb.devuan.org/merged ${DIST} main' > /etc/apt/sources.list.d/devuan.list
+	apt-get update && apt-get --assume-yes \
+		--no-install-recommends \
+		install -t ${DIST} debootstrap
+
 debootstrap \
   --arch="${ARCH}" \
   --verbose \

--- a/scripts/build-debian
+++ b/scripts/build-debian
@@ -94,6 +94,11 @@ cd "${TMP}"
 # Build a Debian root filesystem (first stage)
 case ${OS} in
 debian | ubuntu)
+	RELEASE_KEY="94532124541922FB"
+	echo "Adding Devuan ${DIST} signing key (https://www.devuan.org/os/keyring):" ${RELEASE_KEY}
+	gpg --keyserver keyring.devuan.org --recv-keys ${RELEASE_KEY} && \
+	    gpg --export ${RELEASE_KEY} >/etc/apt/trusted.gpg.d/devuan_key.gpg
+
 	# Get Debian keyring when in Devuan image.
 	apt-get update && apt-get --assume-yes \
 		--no-install-recommends \
@@ -148,7 +153,7 @@ devuan)
 	echo 'deb http://deb.devuan.org/merged ${DIST} main' > /etc/apt/sources.list.d/devuan.list
 	apt-get update && apt-get --assume-yes \
 		--no-install-recommends \
-		install -t ${DIST} debootstrap
+		install --force-yes -t ${DIST} debootstrap
 
 debootstrap \
   --arch="${ARCH}" \

--- a/scripts/build-debian
+++ b/scripts/build-debian
@@ -197,7 +197,8 @@ mv debian/tmp/versions.csv versions.csv
 # >>> ((3800000000 - 32 * 1024 * 1024) // (1024 * 1024)) * (1024 * 1024)
 # 3765436416
 rm -f ext4.img
-fallocate -l 3765436416 ext4.img
+# fallocate fails on some (git CI) COW filesystems, so have a coreutils alternative.
+fallocate -l 3765436416 ext4.img || truncate --size=3765436416 ext4.img
 mkfs.ext4 -d debian ext4.img
 pigz ext4.img
 

--- a/scripts/build-debian
+++ b/scripts/build-debian
@@ -1,6 +1,9 @@
 #!/bin/sh
 # Build Debian root filesystem
 
+echo "Sorry, these scripts worked yesterday."
+exit 1
+
 OS="$1" # For example "debian"
 ARCH="$2" # For example "armhf"
 DIST="$3" # For example "buster"

--- a/scripts/build-debian
+++ b/scripts/build-debian
@@ -240,6 +240,10 @@ deb-src http://deb.devuan.org/merged ${DIST} main
 EOF
 	;;
 devuan-*)
+pwd
+
+ls -l .
+ls -l debian
 	tee debian/tmp/sources.list <<-EOF
 deb http://deb.devuan.org/merged ${DIST} main
 deb-src http://deb.devuan.org/merged ${DIST} main

--- a/scripts/build-debian
+++ b/scripts/build-debian
@@ -44,6 +44,31 @@ ubuntu-armhf|ubuntu-arm64)
 	KERNEL_URL=http://packages.ubuntu.com/"${DIST}"/"${KERNEL}"
 	SCRIPT=/usr/share/debootstrap/scripts/gutsy
 	;;
+devuan-armhf)
+	KERNEL=linux-image-armmp
+	URL=http://deb.devuan.org/merged
+	# 2024-05-01 pkginfo.devuan.org does not have info for armhf.
+	KERNEL_URL=https://pkginfo.devuan.org/cgi-bin/policy-query.html?c=package&q=${KERNEL}
+	SCRIPT=/usr/share/debootstrap/scripts/ceres
+	;;
+devuan-arm64)
+	KERNEL=linux-image-arm64
+	URL=http://deb.devuan.org/merged
+	KERNEL_URL=https://pkginfo.devuan.org/cgi-bin/policy-query.html?c=package&q=${KERNEL}
+	SCRIPT=/usr/share/debootstrap/scripts/ceres
+	;;
+devuan-i386)
+	KERNEL=linux-image-686
+	URL=http://deb.devuan.org/merged
+	KERNEL_URL=https://pkginfo.devuan.org/cgi-bin/policy-query.html?c=package&q=${KERNEL}
+	SCRIPT=/usr/share/debootstrap/scripts/ceres
+	;;
+devuan-amd64)
+	KERNEL=linux-image-amd64
+	URL=http://deb.devuan.org/merged
+	KERNEL_URL=https://pkginfo.devuan.org/cgi-bin/policy-query.html?c=package&q=${KERNEL}
+	SCRIPT=/usr/share/debootstrap/scripts/ceres
+	;;
 *)
 	echo "Can't decide kernel package for \"${ARCH}\""
 	exit 1
@@ -67,6 +92,8 @@ trap 'rm -rf "${TMP}"' EXIT INT TERM
 cd "${TMP}"
 
 # Build a Debian root filesystem (first stage)
+case ${OS} in
+debian | ubuntu)
 debootstrap \
   --arch="${ARCH}" \
   --verbose \
@@ -84,6 +111,28 @@ nano \
   debian \
   "${URL}" \
   "${SCRIPT}"
+	;;
+devuan)
+debootstrap \
+  --arch="${ARCH}" \
+  --verbose \
+  --variant=minbase \
+  --foreign \
+  --include=\
+netbase,\
+net-tools,\
+sysvinit,\
+u-boot-tools,\
+initramfs-tools,\
+openssh-server,\
+nano,\
+vim-tiny \
+  "${TARGET}" \
+  debian \
+  "${URL}" \
+  "${SCRIPT}"
+	;;
+esac
 
 # Randomly generated root password
 PASSWORD="${PASSWORD_OVERRIDE:-$(pwgen -B -A 6 1)}"
@@ -134,6 +183,23 @@ deb http://ports.ubuntu.com/ubuntu-ports ${DIST}-security main universe
 deb-src http://ports.ubuntu.com/ubuntu-ports ${DIST}-security main universe
 EOF
 	;;
+devuan-*-ceres | devuan-*-unstable)
+	# https://pkginfo.devuan.org/sources.list.txt
+	tee debian/tmp/sources.list <<-EOF
+deb http://deb.devuan.org/merged ${DIST} main
+deb-src http://deb.devuan.org/merged ${DIST} main
+EOF
+	;;
+devuan-*)
+	tee debian/tmp/sources.list <<-EOF
+deb http://deb.devuan.org/merged ${DIST} main
+deb-src http://deb.devuan.org/merged ${DIST} main
+deb http://deb.devuan.org/merged ${DIST}-updates main
+deb-src http://deb.devuan.org/merged ${DIST}-updates main
+deb http://deb.devuan.org/merged ${DIST}-security main
+deb-src http://deb.devuan.org/merged ${DIST}-security main
+EOF
+	;;
 esac
 
 case "${OS}-${ARCH}-${DIST}" in
@@ -156,7 +222,10 @@ cp -rv --preserve=mode ../2nd-stage-files/pre-2nd-stage-files-${ARCH}/* debian
 cp -v /usr/bin/qemu-*-static debian/usr/bin || :
 
 # Build a Debian root filesystem (second stage)
-chroot debian /bin/sh -ex <<- EOF
+case "${OS}" in
+debian | ubuntu)
+	# Build a Debian root filesystem (second stage)
+chroot debian /bin/sh -ex <<-EOF
 /debootstrap/debootstrap --second-stage
 /bin/mv /tmp/sources.list /etc/apt/sources.list
 /bin/mv /tmp/priority-experimental /etc/apt/preferences.d/priority-experimental || :
@@ -176,6 +245,28 @@ echo "kernel-url,${KERNEL_URL}\n" >> /tmp/versions.csv
 /bin/echo "root:${PASSWORD}" | /usr/sbin/chpasswd
 /bin/sed -i "s/#*\s*PermitRootLogin .*/PermitRootLogin yes/" /etc/ssh/sshd_config
 EOF
+	;;
+devuan)
+	# Build a Devuan root filesystem (second stage)
+chroot debian /bin/sh -ex <<-EOF
+/debootstrap/debootstrap --second-stage
+/bin/mv /tmp/sources.list /etc/apt/sources.list
+# /usr/bin/apt-key add /etc/apt/trusted.gpg.d/devuan_key.gpg
+/usr/bin/apt-get update
+/usr/bin/apt-get -y upgrade
+/usr/bin/apt-get -y --no-install-recommends "${KERNELSUITE}" install "${KERNEL}"
+/usr/bin/apt-get -y install connman || :
+/usr/bin/apt-get -y install openntpd || :
+/usr/bin/apt-get clean
+/bin/rm -rf /var/lib/apt/lists/*
+echo "kernel-url,${KERNEL_URL}\n" >> /tmp/versions.csv
+/usr/bin/dpkg-query --showformat='kernel,\${Version}\n' --show "${KERNEL}" > /tmp/versions.csv
+/bin/rm -f /var/log/*.log
+/bin/echo "root:${PASSWORD}" | /usr/sbin/chpasswd
+/bin/sed -i "s/#*\s*PermitRootLogin .*/PermitRootLogin yes/" /etc/ssh/sshd_config
+EOF
+	;;
+esac
 
 # Remove ARM emulation stuff again
 rm -v debian/usr/bin/qemu-*-static || :
@@ -186,7 +277,14 @@ cp -rv --preserve=mode ../2nd-stage-files/post-2nd-stage-files/* debian
 echo "${OS}" > debian/etc/hostname
 
 # Set resolv.conf
-ln -sf /run/systemd/resolve/stub-resolv.conf debian/etc/resolv.conf
+case "${OS}" in
+debian | ubuntu)
+	ln -sf /run/systemd/resolve/stub-resolv.conf debian/etc/resolv.conf
+	;;
+devuan)
+	ln -sf /run/connman/resolv.conf debian/etc/resolv.conf
+	;;
+esac
 
 # List all files
 find debian ! -type d -printf "/%P\n" | sort > files.txt

--- a/scripts/build-image
+++ b/scripts/build-image
@@ -14,7 +14,8 @@ if [ $IMAGE_SIZE -lt 1000000000 ]; then
   exit 1
 fi
 rm -f "${IMAGE}"
-fallocate -v -l "${IMAGE_SIZE}" "${IMAGE}" # 3,800,000,000 bytes
+# fallocate fails on some (git CI) COW filesystems, so have a coreutils alternative.
+fallocate -v -l "${IMAGE_SIZE}" "${IMAGE}" || truncate --size "${IMAGE_SIZE}" "${IMAGE}" # 3,800,000,000 bytes
 
 parted -s "${IMAGE}" mklabel msdos
 parted -s "${IMAGE}" mkpart primary fat32 -- 4MiB 32MiB # 28 MiB (29,360,128 bytes)
@@ -23,7 +24,8 @@ parted -s "${IMAGE}" set 2 boot on
 
 # Create empty FAT partition
 rm -f vfat.img
-fallocate -l 28MiB vfat.img
+# fallocate fails on some (git CI) COW filesystems, so have a coreutils alternative.
+fallocate -l 28MiB vfat.img || truncate --size 28MiB vfat.img
 mkfs.vfat vfat.img
 
 # Leave a friendly note about this partition

--- a/test/qemu.sh
+++ b/test/qemu.sh
@@ -31,7 +31,8 @@ LOOP1=$(losetup -f -P --show image.bin) && {
 }
 
 # Assume 8GB virtual disk
-fallocate -l 8GB image.bin
+# fallocate fails on some (git CI) COW filesystems, so have a coreutils alternative.
+fallocate -l 8GB image.bin || truncate --size 8GB image.bin
 
 # Extend second partition
 parted -s -a opt image.bin "resizepart 2 100%"


### PR DESCRIPTION
rebuild-debian-csv now gets codenames from the Debian,
Ubuntu and Devuan repository web pages, because
Devuan does not have an ls-lR.gz file.

Adds Dockerfile.devuan to build from a Devuan image.

README_devuan.md extends README.md.

Fix for when fallocate fails on (git CI) COW filesystems.
